### PR TITLE
Issue-1397: Fix byte range validation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.carlspring.commons</groupId>
     <artifactId>commons-http</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Commons: HTTP</name>

--- a/src/main/java/org/carlspring/commons/http/range/ByteRange.java
+++ b/src/main/java/org/carlspring/commons/http/range/ByteRange.java
@@ -18,8 +18,7 @@ public class ByteRange
     private Long limit;
 
     @Min(value = 0, message = "Range length must be greater than or equal to zero")
-    private Long totalLength;
-
+    private long totalLength = 0L;
 
     public ByteRange()
     {
@@ -57,12 +56,12 @@ public class ByteRange
         this.limit = limit;
     }
 
-    public Long getTotalLength()
+    public long getTotalLength()
     {
         return totalLength;
     }
 
-    public void setTotalLength(Long totalLength)
+    public void setTotalLength(long totalLength)
     {
         this.totalLength = totalLength;
     }

--- a/src/main/java/org/carlspring/commons/http/range/validation/ByteRangeCheckValidator.java
+++ b/src/main/java/org/carlspring/commons/http/range/validation/ByteRangeCheckValidator.java
@@ -25,16 +25,19 @@ public class ByteRangeCheckValidator
         Long start = byteRange.getOffset();
         Long end = byteRange.getLimit();
 
+        // Valid for cases like bytes=500-, where offset is 500 and limit is internally null.
         if (end == null)
         {
             return true;
         }
 
-        if (end <= 0)
+        // Valid for cases like bytes=-500, where offset is internally zero, and limit is -500.
+        if (end < 0)
         {
-            return start >= end;
+            return start == 0;
         }
 
+        // Rest of cases, like bytes=0-0,100-200, etc.
         return end >= start;
 
     }

--- a/src/test/java/org/carlspring/commons/http/range/ByteRangeHeaderParserTest.java
+++ b/src/test/java/org/carlspring/commons/http/range/ByteRangeHeaderParserTest.java
@@ -61,7 +61,7 @@ public class ByteRangeHeaderParserTest
         void testParsingWithOffsetGreaterThaLimitShouldThrowByteRangeValidationException()
         {
             // Given
-            String headerContents = "bytes=50-5";
+            String headerContents = "bytes=50-0";
             ByteRangeHeaderParser parser = new ByteRangeHeaderParser(headerContents);
 
             // When
@@ -157,7 +157,7 @@ public class ByteRangeHeaderParserTest
 
             assertEquals(500, range.getOffset().longValue(), "Failed to parse offset!");
             assertEquals(1000, range.getLimit().longValue(), "Failed to parse end!");
-            assertEquals(0, range.getTotalLength().longValue(), "Failed to parse length!");
+            assertEquals(0, range.getTotalLength(), "Failed to parse length!");
         }
 
         @Test
@@ -174,7 +174,7 @@ public class ByteRangeHeaderParserTest
             ByteRange range = ranges.get(0);
 
             assertEquals(500, range.getOffset().longValue(), "Failed to parse offset!");
-            assertEquals(0, range.getTotalLength().longValue(), "Failed to parse length!");
+            assertEquals(0, range.getTotalLength(), "Failed to parse length!");
         }
 
         @Test
@@ -192,7 +192,7 @@ public class ByteRangeHeaderParserTest
 
             assertEquals(0, range.getOffset().longValue(), "Failed to parse offset!");
             assertEquals(-500, range.getLimit().longValue(), "Failed to parse limit!");
-            assertEquals(0, range.getTotalLength().longValue(), "Failed to parse length!");
+            assertEquals(0, range.getTotalLength(), "Failed to parse length!");
         }
 
         @Test
@@ -210,7 +210,7 @@ public class ByteRangeHeaderParserTest
 
             assertEquals(100, range.getOffset().longValue(), "Failed to parse offset!");
             assertEquals(500, range.getLimit().longValue(), "Failed to parse limit!");
-            assertEquals(1024, range.getTotalLength().longValue(), "Failed to parse length!");
+            assertEquals(1024, range.getTotalLength(), "Failed to parse length!");
         }
     }
 

--- a/src/test/java/org/carlspring/commons/http/range/validation/ByteRangeCheckValidatorTest.java
+++ b/src/test/java/org/carlspring/commons/http/range/validation/ByteRangeCheckValidatorTest.java
@@ -62,11 +62,11 @@ public class ByteRangeCheckValidatorTest
     }
 
     @Test
-    void byteRangeOffSetGreaterThanLimitIsValid()
+    void byteRangeLimitGreaterThanOffsetIsValid()
     {
         // Given
         // Example: 1000-2000 ; Read bytes 1000-2000 (incl.)
-        ByteRange byteRange = new ByteRange(1000L, -2000L);
+        ByteRange byteRange = new ByteRange(1000L, 2000L);
 
         // When
         Set<ConstraintViolation<ByteRange>> violations = validator.validate(byteRange);
@@ -79,7 +79,7 @@ public class ByteRangeCheckValidatorTest
     void byteRangeOffsetGreaterThanLimitIsNotValid()
     {
         // Given
-        ByteRange byteRange = new ByteRange(500L, 100L);
+        ByteRange byteRange = new ByteRange(50L, 0L);
 
         // When
         Set<ConstraintViolation<ByteRange>> violations = validator.validate(byteRange);


### PR DESCRIPTION
Related to strongbox/strongbox#1397.

## Tasks
- [x] Fix byte range validation, which was validating as correct when `offset` is greater than zero and `limit` equal to zero, e.g.: `bytes=50-0`. This is now validated as incorrect.
- [x] Set version to `1.2.1`.