### PR TITLE
Issue-1397: Remove unused commons-io dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.carlspring.commons</groupId>
     <artifactId>commons-http</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Commons: HTTP</name>
@@ -121,12 +121,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.carlspring.commons</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>1.0</version>
-        </dependency>
-
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.carlspring.commons</groupId>
     <artifactId>commons-http</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Commons: HTTP</name>


### PR DESCRIPTION
Related to strongbox/strongbox#1397.

## Tasks
- [x] Remove unused `org.carlspring.commons-io` dependency. This is necessary because I'm going to add a dependency `commons-http` in `commons-io`, to avoid circular dependencies (see [PR](https://github.com/carlspring/commons-io/pull/6))
- [x] Set version to `1.3`.